### PR TITLE
执行composer命令报错

### DIFF
--- a/src/Commands/ModuleCreateCommand.php
+++ b/src/Commands/ModuleCreateCommand.php
@@ -38,6 +38,10 @@ class ModuleCreateCommand extends Command
         $studlyName = implode($studlyName);
 
         $author = $this->ask('请输入作者名（必填）');
+        if (empty($author)) {
+            $this->error('请输入作者名');
+            return self::FAILURE;
+        }
         $email = $this->ask('请输入邮箱地址（选填）');
         $description = $this->ask('请输入应用简介（选填）');
         $homepage = $this->ask('请输入主页地址（选填）');
@@ -51,9 +55,9 @@ class ModuleCreateCommand extends Command
             'studlyName' => $studlyName,
             'lowerName' => strtolower($name),
             'author' => $author,
-            'email' => $email,
+            'email' => $email ?: "{$author}@{$author}.com",
             'description' => $description,
-            'homepage' => $homepage,
+            'homepage' => $homepage ?: "https://{$author}.com",
             'namespace' => $namespace,
             'namespaceComposer' => $namespaceComposer
         ];


### PR DESCRIPTION
1. composer 版本2.3.5； 运行composer命令不允许email和homepage空值
2. composer.stub模板不太好调整 

最终采用：如果不设定就给默认值